### PR TITLE
Hotfix/uc4 typo

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="Kleur bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Kleur bewaren " Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
De test voor UC4 faalde omdat de knop "wijzig kleur" heette, terwijl de functionele eis "Kleur bewaren" vereist.
Tekst aangepast.  test zou nu moeten slagen.